### PR TITLE
Add a `copyIconBuilder` option for `MarkdownViewer` and `MarkdownRenderer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.6-dev
+
+- Add a `copyIconBuilder` option for `MarkdownViewer` and `MarkdownRenderer` to
+  customise the copy icon.
+
 ## 0.4.5
 
 - Update to `dart_markdown` 3.1.3.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -49,7 +49,7 @@ packages:
       name: dart_markdown
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.3"
   dart_prism:
     dependency: transitive
     description:
@@ -101,7 +101,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.3"
+    version: "0.4.6-dev"
   matcher:
     dependency: transitive
     description:

--- a/lib/src/builders/code_block_builder.dart
+++ b/lib/src/builders/code_block_builder.dart
@@ -79,7 +79,7 @@ class CodeBlockBuilder extends MarkdownElementBuilder {
             top: 0,
             child: CopyButton(
               textWidget,
-              copyIconBuilder: copyIconBuilder,
+              iconBuilder: copyIconBuilder,
             ),
           ),
         ],

--- a/lib/src/builders/code_block_builder.dart
+++ b/lib/src/builders/code_block_builder.dart
@@ -10,11 +10,13 @@ class CodeBlockBuilder extends MarkdownElementBuilder {
     this.padding,
     this.decoration,
     this.highlightBuilder,
+    this.copyIconBuilder,
   }) : super(textStyle: textStyle);
 
   final EdgeInsets? padding;
   final BoxDecoration? decoration;
   final MarkdownHighlightBuilder? highlightBuilder;
+  final CopyIconBuilder? copyIconBuilder;
 
   @override
   final matchTypes = ['codeBlock'];
@@ -72,7 +74,14 @@ class CodeBlockBuilder extends MarkdownElementBuilder {
               child: textWidget,
             ),
           ),
-          Positioned(right: 0, top: 0, child: CopyButton(textWidget)),
+          Positioned(
+            right: 0,
+            top: 0,
+            child: CopyButton(
+              textWidget,
+              copyIconBuilder: copyIconBuilder,
+            ),
+          ),
         ],
       );
     } else {

--- a/lib/src/definition.dart
+++ b/lib/src/definition.dart
@@ -63,3 +63,5 @@ typedef MarkdownHighlightBuilder = List<TextSpan> Function(
   String? language,
   String? infoString,
 );
+
+typedef CopyIconBuilder = Widget Function(bool copied);

--- a/lib/src/renderer.dart
+++ b/lib/src/renderer.dart
@@ -37,6 +37,7 @@ class MarkdownRenderer implements NodeVisitor {
     TextAlign? textAlign,
     Color? selectionColor,
     SelectionRegistrar? selectionRegistrar,
+    CopyIconBuilder? copyIconBuilder,
   })  : _selectionColor = selectionColor,
         _selectionRegistrar = selectionRegistrar,
         _blockSpacing = styleSheet.blockSpacing,
@@ -96,6 +97,7 @@ class MarkdownRenderer implements NodeVisitor {
         padding: styleSheet.codeblockPadding,
         decoration: styleSheet.codeblockDecoration,
         highlightBuilder: highlightBuilder,
+        copyIconBuilder: copyIconBuilder,
       ),
       BlockquoteBuilder(
         textStyle: styleSheet.blockquote,

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -29,6 +29,7 @@ class MarkdownViewer extends StatefulWidget {
     this.syntaxExtensions = const [],
     this.nodesFilter,
     this.selectionColor = const Color(0x4a006ff8),
+    this.copyIconBuilder,
     Key? key,
   }) : super(key: key);
 
@@ -50,6 +51,7 @@ class MarkdownViewer extends StatefulWidget {
   final List<MarkdownElementBuilder> elementBuilders;
   final List<md.Syntax> syntaxExtensions;
   final Color? selectionColor;
+  final CopyIconBuilder? copyIconBuilder;
 
   /// A function used to modify the parsed AST nodes.
   ///
@@ -120,6 +122,7 @@ class _MarkdownViewerState extends State<MarkdownViewer> {
       elementBuilders: widget.elementBuilders,
       selectionColor: widget.selectionColor,
       selectionRegistrar: selectionRegistrar,
+      copyIconBuilder: widget.copyIconBuilder,
     );
 
     var astNodes = markdown.parse(widget.data);

--- a/lib/src/widgets/copy_button.dart
+++ b/lib/src/widgets/copy_button.dart
@@ -6,12 +6,12 @@ import '../definition.dart';
 class CopyButton extends StatefulWidget {
   const CopyButton(
     this.textWidget, {
-    this.copyIconBuilder,
+    this.iconBuilder,
     super.key,
   });
 
   final Widget textWidget;
-  final CopyIconBuilder? copyIconBuilder;
+  final CopyIconBuilder? iconBuilder;
 
   @override
   State<CopyButton> createState() => _CopyButtonState();
@@ -27,7 +27,7 @@ class _CopyButtonState extends State<CopyButton> {
       shape: const CircleBorder(),
       child: InkWell(
         borderRadius: BorderRadius.circular(30),
-        child: widget.copyIconBuilder == null
+        child: widget.iconBuilder == null
             ? SizedBox(
                 width: 36,
                 height: 36,
@@ -37,7 +37,7 @@ class _CopyButtonState extends State<CopyButton> {
                   color: _copied ? Colors.black : Colors.black54,
                 ),
               )
-            : widget.copyIconBuilder!(_copied),
+            : widget.iconBuilder!(_copied),
         onTap: () async {
           final textWidget = widget.textWidget;
           String? text;

--- a/lib/src/widgets/copy_button.dart
+++ b/lib/src/widgets/copy_button.dart
@@ -1,13 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import '../definition.dart';
+
 class CopyButton extends StatefulWidget {
   const CopyButton(
     this.textWidget, {
+    this.copyIconBuilder,
     super.key,
   });
 
   final Widget textWidget;
+  final CopyIconBuilder? copyIconBuilder;
 
   @override
   State<CopyButton> createState() => _CopyButtonState();
@@ -22,16 +26,18 @@ class _CopyButtonState extends State<CopyButton> {
       color: Colors.transparent,
       shape: const CircleBorder(),
       child: InkWell(
-        borderRadius: BorderRadius.circular(20),
-        child: SizedBox(
-          width: 36,
-          height: 36,
-          child: Icon(
-            _copied ? Icons.check : Icons.copy_rounded,
-            size: 18,
-            color: _copied ? Colors.black : Colors.black54,
-          ),
-        ),
+        borderRadius: BorderRadius.circular(30),
+        child: widget.copyIconBuilder == null
+            ? SizedBox(
+                width: 36,
+                height: 36,
+                child: Icon(
+                  _copied ? Icons.check : Icons.copy_rounded,
+                  size: 18,
+                  color: _copied ? Colors.black : Colors.black54,
+                ),
+              )
+            : widget.copyIconBuilder!(_copied),
         onTap: () async {
           final textWidget = widget.textWidget;
           String? text;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: markdown_viewer
 description: A Markdown renderer for Flutter. Render Markdown String to rich
   text output.
-version: 0.4.5
+version: 0.4.6-dev
 repository: https://github.com/tagnote-app/markdown_viewer
 
 environment:


### PR DESCRIPTION
Example:
```dart
MarkdownViewer(
...
  copyIconBuilder: (copied) {
    return Padding(
      padding: const EdgeInsets.all(4),
      child: Text(copied ? 'copied' : 'copy'),
    );
  },
...
);
```
Fix https://github.com/tagnote-app/markdown_viewer/issues/59