### PR TITLE
Add copyIconColor to MarkdownStyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.10-dev
+
+- Add `copyIconColor` to `MarkdownStyle`.
+
 ## 0.4.9
 
 - Fix a `mergeRichText` issue.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -101,7 +101,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.9"
+    version: "0.4.10-dev"
   matcher:
     dependency: transitive
     description:

--- a/lib/src/builders/code_block_builder.dart
+++ b/lib/src/builders/code_block_builder.dart
@@ -11,12 +11,14 @@ class CodeBlockBuilder extends MarkdownElementBuilder {
     this.decoration,
     this.highlightBuilder,
     this.copyIconBuilder,
+    this.copyIconColor,
   }) : super(textStyle: textStyle);
 
   final EdgeInsets? padding;
   final BoxDecoration? decoration;
   final MarkdownHighlightBuilder? highlightBuilder;
   final CopyIconBuilder? copyIconBuilder;
+  final Color? copyIconColor;
 
   @override
   final matchTypes = ['codeBlock'];
@@ -79,6 +81,7 @@ class CodeBlockBuilder extends MarkdownElementBuilder {
             top: 0,
             child: CopyButton(
               textWidget,
+              iconColor: copyIconColor,
               iconBuilder: copyIconBuilder,
             ),
           ),

--- a/lib/src/renderer.dart
+++ b/lib/src/renderer.dart
@@ -98,6 +98,7 @@ class MarkdownRenderer implements NodeVisitor {
         decoration: styleSheet.codeblockDecoration,
         highlightBuilder: highlightBuilder,
         copyIconBuilder: copyIconBuilder,
+        copyIconColor: styleSheet.copyIconColor,
       ),
       BlockquoteBuilder(
         textStyle: styleSheet.blockquote,

--- a/lib/src/style.dart
+++ b/lib/src/style.dart
@@ -57,6 +57,7 @@ class MarkdownStyle {
     this.codeblockPadding,
     this.codeblockDecoration,
     this.blockSpacing = 8.0,
+    this.copyIconColor,
   });
 
   final TextStyle? textStyle;
@@ -111,6 +112,7 @@ class MarkdownStyle {
   final TextStyle? codeBlock;
   final EdgeInsets? codeblockPadding;
   final BoxDecoration? codeblockDecoration;
+  final Color? copyIconColor;
 
   /// The vertical space between two block elements.
   final double blockSpacing;

--- a/lib/src/widgets/copy_button.dart
+++ b/lib/src/widgets/copy_button.dart
@@ -7,11 +7,13 @@ class CopyButton extends StatefulWidget {
   const CopyButton(
     this.textWidget, {
     this.iconBuilder,
+    this.iconColor,
     super.key,
   });
 
   final Widget textWidget;
   final CopyIconBuilder? iconBuilder;
+  final Color? iconColor;
 
   @override
   State<CopyButton> createState() => _CopyButtonState();
@@ -34,7 +36,7 @@ class _CopyButtonState extends State<CopyButton> {
                 child: Icon(
                   _copied ? Icons.check : Icons.copy_rounded,
                   size: 18,
-                  color: _copied ? Colors.black : Colors.black54,
+                  color: widget.iconColor ?? const Color(0xff999999),
                 ),
               )
             : widget.iconBuilder!(_copied),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: markdown_viewer
 description: A Markdown renderer for Flutter. Render Markdown String to rich
   text output.
-version: 0.4.9
+version: 0.4.10-dev
 repository: https://github.com/tagnote-app/markdown_viewer
 
 environment:


### PR DESCRIPTION
Example:
```dart
const style = MarkdownStyle(
  copyIconColor: Colors.green,
);
```